### PR TITLE
feat: add directory exclusion capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,24 @@ Options:
   -e, --ext      File extensions to include (comma-separated)
                                                        [string] [default: ".md"]
   -o, --output   File path to save the TOC     [string] [default: "./README.md"]
+  -x, --exclude  Directories to exclude (comma-separated)              [string]
   -h, --help     Show help                                             [boolean]
 ```
 
 ```
 repo-toc
+```
+
+### Usage Examples
+
+Generate TOC excluding specific directories:
+```bash
+repo-toc --exclude node_modules,dist,build
+```
+
+Generate TOC for only JavaScript files, excluding test directories:
+```bash
+repo-toc --ext .js,.ts --exclude tests,__tests__,spec
 ```
 
 ### Use with Github actions
@@ -110,6 +123,13 @@ const filePath = __dirname + "/" + "README.md";
 fs.writeFileSync(filePath, "## Table of contents");
 generateTableOfContent({ dirPath, filePath });
 
+// Generate TOC excluding specific directories
+generateTableOfContent({
+  dirPath: __dirname,
+  filePath: "./README.md",
+  excludedDirs: ["node_modules", "dist", "build"]
+});
+
 // Call the function to generate the TOC
 generateTableOfContent();
 // It will update the README.md file with the Table of Contents
@@ -129,6 +149,8 @@ Generates a Table of Contents for the specified directory.
     - Default: `[".md"]`.  
   - **`filePath`** (string): The path where the generated TOC will be written.  
     - Default: `__dirname + "/README.md"`.
+  - **`excludedDirs`** (array of strings): An array of directory names to exclude from the TOC.  
+    - Default: `[]`. Note: Directories starting with `.` are automatically excluded.
 
 **Returns**:  
 `void`

--- a/cli.js
+++ b/cli.js
@@ -27,6 +27,13 @@ yargs
     demandOption: false,
     default: "./README.md",
   })
+  .option("exclude", {
+    alias: "x",
+    describe: "Directories to exclude (comma-separated)",
+    type: "string",
+    demandOption: false,
+    default: "",
+  })
   .help()
   .alias("help", "h").argv;
 
@@ -34,5 +41,6 @@ const options = yargs.argv;
 const dirPath = options.dir;
 const extensions = options.ext.split(",");
 const filePath = options.output;
+const excludedDirs = options.exclude.split(",").filter(dir => dir.trim() !== "");
 
-generateTableOfContent({ dirPath, extensions, filePath });
+generateTableOfContent({ dirPath, extensions, filePath, excludedDirs });

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,13 +3,20 @@ const path = require("path");
 
 const { shouldSkipFolder, getFileTitle } = require("./utils");
 
-function getTableOfContents({ dirPath = process.cwd(), extensions = [] }) {
+function getTableOfContents({ dirPath = process.cwd(), extensions = [], excludedDirs = [] }) {
   try {
     if (
       !Array.isArray(extensions) ||
       extensions.some((ext) => typeof ext !== "string")
     ) {
       throw new Error("Extensions must be an array of strings.");
+    }
+
+    if (
+      !Array.isArray(excludedDirs) ||
+      excludedDirs.some((dir) => typeof dir !== "string")
+    ) {
+      throw new Error("Excluded directories must be an array of strings.");
     }
 
     let toc = "";
@@ -22,7 +29,7 @@ function getTableOfContents({ dirPath = process.cwd(), extensions = [] }) {
         const stat = fs.statSync(fullPath);
 
         if (stat.isDirectory()) {
-          if (shouldSkipFolder(file)) {
+          if (shouldSkipFolder(file, excludedDirs)) {
             continue;
           }
           toc += `${" ".repeat(level * 2)}* **${file}**\n`;
@@ -82,10 +89,11 @@ function generateTableOfContent({
   dirPath = process.cwd(),
   extensions = [".md"],
   filePath = __dirname + "/README.md",
+  excludedDirs = [],
 }) {
   updateTOC({
     filePath,
-    contentToAdd: getTableOfContents({ dirPath, extensions }),
+    contentToAdd: getTableOfContents({ dirPath, extensions, excludedDirs }),
   });
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,14 @@
 const fs = require("fs");
 const path = require("path");
 
-function shouldSkipFolder(folderName) {
-  return folderName.startsWith(".");
+function shouldSkipFolder(folderName, excludedDirs = []) {
+  // Skip folders starting with dot (hidden folders)
+  if (folderName.startsWith(".")) {
+    return true;
+  }
+  
+  // Skip folders in the excluded directories list
+  return excludedDirs.includes(folderName);
 }
 
 function getDefaultFileTitle(filePath) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "repo-toc",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "repo-toc",
-      "version": "1.0.1",
+      "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
         "yargs": "^17.7.2"
+      },
+      "bin": {
+        "repo-toc": "cli.js"
       },
       "devDependencies": {
         "jest": "^29.7.0"

--- a/tests/generateTableOfContents.spec.js
+++ b/tests/generateTableOfContents.spec.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
-const { generateTableOfContent } = require("../lib");
+const path = require("path");
+const { generateTableOfContent, getTableOfContents } = require("../lib");
 
 describe("generateTableOfContents", () => {
   test("should generate TOC on marker less markdown file", () => {
@@ -45,5 +46,70 @@ describe("generateTableOfContents", () => {
         throw err;
       }
     });
+  });
+
+  test("should exclude specified directories from TOC", () => {
+    const dirPath = __dirname + "/mocks";
+    
+    // Create a temporary directory to exclude
+    const tempDir = path.join(dirPath, "temp-exclude");
+    if (!fs.existsSync(tempDir)) {
+      fs.mkdirSync(tempDir);
+    }
+    
+    // Create a markdown file in the temp directory
+    const tempFile = path.join(tempDir, "temp.md");
+    fs.writeFileSync(tempFile, "# Temporary File\n\nThis should be excluded.");
+
+    try {
+      // Generate TOC without exclusions
+      const tocWithoutExclusions = getTableOfContents({ 
+        dirPath, 
+        extensions: [".md"] 
+      });
+      
+      // Generate TOC with exclusions
+      const tocWithExclusions = getTableOfContents({ 
+        dirPath, 
+        extensions: [".md"],
+        excludedDirs: ["temp-exclude"]
+      });
+
+      // The version with exclusions should not contain the temp directory
+      expect(tocWithoutExclusions).toContain("temp-exclude");
+      expect(tocWithExclusions).not.toContain("temp-exclude");
+      expect(tocWithExclusions).not.toContain("Temporary File");
+      
+      // Both should still contain the other test files
+      expect(tocWithoutExclusions).toContain("TestFile3");
+      expect(tocWithExclusions).toContain("TestFile3");
+      
+    } finally {
+      // Clean up temporary files
+      if (fs.existsSync(tempFile)) {
+        fs.unlinkSync(tempFile);
+      }
+      if (fs.existsSync(tempDir)) {
+        fs.rmdirSync(tempDir);
+      }
+    }
+  });
+
+  test("should exclude multiple directories from TOC", () => {
+    const dirPath = __dirname + "/mocks";
+    
+    // Test excluding the existing test-files directory
+    const tocWithExclusions = getTableOfContents({ 
+      dirPath, 
+      extensions: [".md"],
+      excludedDirs: ["test-files"]
+    });
+
+    // Should not contain the excluded directory
+    expect(tocWithExclusions).not.toContain("test-files");
+    expect(tocWithExclusions).not.toContain("Test File 1 Title");
+    
+    // Should still contain files in the root
+    expect(tocWithExclusions).toContain("TestFile3");
   });
 });


### PR DESCRIPTION
- Add --exclude/-x CLI option to exclude directories from TOC generation
- Support comma-separated list of directory names to exclude
- Update shouldSkipFolder function to handle user-defined exclusions
- Add excludedDirs parameter to API functions (getTableOfContents, generateTableOfContent)
- Add comprehensive tests for directory exclusion functionality
- Update README with usage examples and API documentation
- Maintain backward compatibility with existing functionality